### PR TITLE
Fix: Run workflow on pull_request

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -3,7 +3,7 @@
 name: "Integrate"
 
 on: # yamllint disable-line rule:truthy
-  pull_request_target: null
+  pull_request: null
   push:
     branches:
       - "main"


### PR DESCRIPTION
This pull request

* [x] runs the integrate workflow on the `pull_request` event