### PR TITLE
Fix: Do not let dependabot update `symfony/yaml`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
       include: "scope"
       prefix: "composer"
     directory: "/"
+    ignore:
+      - dependency-name: "symfony/yaml"
     labels:
       - "dependency"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request

- [x] configures dependabot to ignore updates for `symfony/yaml`