### PR TITLE
Fix: Allow installation of `symfony/yaml:^6.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "symfony/yaml": "^5.4.3"
+    "symfony/yaml": "^5.0.0 || ^6.0.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.24.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71646338b29b7c7508c24dc68b0bfa61",
+    "content-hash": "8581b62585ba681090109639172db056",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
This pull request

- [x] allows installation of `symfony/yaml:^6.0.0` (again)