### PR TITLE
Fix: Use `~` operator to limit compatibility with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/ergebnis/front-matter"
   },
   "require": {
-    "php": "^8.0",
+    "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "symfony/yaml": "^5.0.0 || ^6.0.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c9aafb22edd5730e5c3b61c106b6b98",
+    "content-hash": "a0d75895e0876802bd977f8e26a9220c",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",
@@ -6010,7 +6010,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This pull request

- [x] uses the `~` operator to limit the compatibility with PHP versions 

Follows https://github.com/ergebnis/php-package-template/pull/1086.