### PR TITLE
Enhancement: Allow accessing front-matter values using `.`-notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.0.0...main`][2.0.0...main].
 
+### Changed
+
+- Allowed using dot notation to access values in `FrontMatter` ([#346]), by [@localheinz]
+
 ## [`2.0.0`][2.0.0]
 
 For a full diff see [`1.0.0...2.0.0`][1.0.0...2.0.0].
@@ -84,5 +88,6 @@ For a full diff see [`4e97e14...0.1.0`][4e97e14...0.1.0].
 [#341]: https://github.com/ergebnis/front-matter/pull/341
 [#342]: https://github.com/ergebnis/front-matter/pull/342
 [#344]: https://github.com/ergebnis/front-matter/pull/344
+[#346]: https://github.com/ergebnis/front-matter/pull/346
 
 [@localheinz]: https://github.com/localheinz

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,6 +4,14 @@
     <DocblockTypeContradiction>
       <code>return !\is_string($key);</code>
     </DocblockTypeContradiction>
+    <MixedArgument>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
   </file>
   <file src="src/YamlParser.php">
     <MixedArgumentTypeCoercion>
@@ -16,6 +24,8 @@
       <code>$key</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
+      <code>$value</code>
+      <code>$value</code>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayOffset>

--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -45,7 +45,40 @@ final class FrontMatter
 
     public function has(string $key): bool
     {
-        return \array_key_exists($key, $this->value);
+        if (!\str_contains($key, '.')) {
+            return \array_key_exists(
+                $key,
+                $this->value,
+            );
+        }
+
+        /** @var array<int, string> $parts */
+        $parts = \explode(
+            '.',
+            $key,
+        );
+
+        $count = \count($parts);
+        $value = $this->value;
+
+        for ($i = 0; $i < $count; ++$i) {
+            $part = $parts[$i];
+
+            if (!\array_key_exists($part, $value)) {
+                return false;
+            }
+
+            $value = $value[$part];
+
+            if (
+                $count - 1 > $i
+                && !\is_array($value)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -53,11 +86,41 @@ final class FrontMatter
      */
     public function get(string $key): mixed
     {
-        if (!\array_key_exists($key, $this->value)) {
-            throw Exception\FrontMatterDoesNotHaveKey::named($key);
+        if (!\str_contains($key, '.')) {
+            if (!\array_key_exists($key, $this->value)) {
+                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+            }
+
+            return $this->value[$key];
         }
 
-        return $this->value[$key];
+        /** @var array<int, string> $parts */
+        $parts = \explode(
+            '.',
+            $key,
+        );
+
+        $count = \count($parts);
+        $value = $this->value;
+
+        for ($i = 0; $i < $count; ++$i) {
+            $part = $parts[$i];
+
+            if (!\array_key_exists($part, $value)) {
+                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+            }
+
+            $value = $value[$part];
+
+            if (
+                $count - 1 > $i
+                && !\is_array($value)
+            ) {
+                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/test/Unit/FrontMatterTest.php
+++ b/test/Unit/FrontMatterTest.php
@@ -94,6 +94,77 @@ final class FrontMatterTest extends Framework\TestCase
         self::assertTrue($frontMatter->has($key));
     }
 
+    /**
+     * @dataProvider provideFrontMatterWhereValueIsMissingWhenKeyUsesDotNotation
+     */
+    public function testHasReturnsFalseWhenFrontMatterDoesNotHaveValueWhenKeyUsesDotNotation(array $value): void
+    {
+        $frontMatter = FrontMatter::fromArray($value);
+
+        self::assertFalse($frontMatter->has('head.meta.author'));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array}>
+     */
+    public static function provideFrontMatterWhereValueIsMissingWhenKeyUsesDotNotation(): \Generator
+    {
+        $faker = self::faker();
+
+        $values = [
+            'head-not-present' => [
+                'other' => $faker->word(),
+            ],
+            'head-present-but-value-is-string' => [
+                'head' => $faker->word(),
+            ],
+            'head-present-but-value-is-array-where-keys-are-integers' => [
+                'head' => $faker->words(),
+            ],
+            'head.meta-present-but-value-is-string' => [
+                'head' => [
+                    'meta' => $faker->word(),
+                ],
+            ],
+            'head.meta-present-but-value-is-array-where-keys-are-integers' => [
+                'head' => [
+                    'meta' => $faker->words(),
+                ],
+            ],
+            'head.meta-present-as-key' => [
+                'head.meta' => [
+                    'author' => $faker->word(),
+                ],
+            ],
+            'head.meta.author-present-as-key' => [
+                'head.meta.author' => $faker->word(),
+            ],
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    public function testHasReturnsTrueWhenFrontMatterHasFullyExplodedPartsAndKeyUsesDotNotation(): void
+    {
+        $faker = self::faker();
+
+        $value = [
+            'head' => [
+                'meta' => [
+                    'author' => $faker->name(),
+                ],
+            ],
+        ];
+
+        $frontMatter = FrontMatter::fromArray($value);
+
+        self::assertTrue($frontMatter->has('head.meta.author'));
+    }
+
     public function testGetThrowsFrontMatterDoesNotHaveKeyExceptionWhenFrontMatterIsEmpty(): void
     {
         $key = self::faker()->word();
@@ -137,5 +208,34 @@ final class FrontMatterTest extends Framework\TestCase
         $frontMatter = FrontMatter::fromArray($value);
 
         self::assertSame($value[$key], $frontMatter->get($key));
+    }
+
+    /**
+     * @dataProvider provideFrontMatterWhereValueIsMissingWhenKeyUsesDotNotation
+     */
+    public function testGetThrowsFrontMatterDoesNotHaveValueExceptionWhenFrontMatterDoesNotHaveValueAndKeyUsesDotNotation(array $value): void
+    {
+        $frontMatter = FrontMatter::fromArray($value);
+
+        $this->expectException(Exception\FrontMatterDoesNotHaveKey::class);
+
+        $frontMatter->get('head.meta.author');
+    }
+
+    public function testGetReturnsValueWhenFrontMatterHasFullyExplodedPartsAndKeyUsesDotNotation(): void
+    {
+        $author = self::faker()->name();
+
+        $value = [
+            'head' => [
+                'meta' => [
+                    'author' => $author,
+                ],
+            ],
+        ];
+
+        $frontMatter = FrontMatter::fromArray($value);
+
+        self::assertSame($author, $frontMatter->get('head.meta.author'));
     }
 }


### PR DESCRIPTION
This pull request

- [x] allows using `.`-notation for accessing front-matter values

Fixes #345.
