### PR TITLE
Fix: Rename constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.1.0...main`][2.1.0...main].
 ### Changed
 
 - Dropped support for PHP 8.0 ([#393]), by [@localheinz]
+- Renamed `Parsed::fromFrontMatterAndContent()` to `Parsed::create()` ([#397]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -100,5 +101,6 @@ For a full diff see [`4e97e14...0.1.0`][4e97e14...0.1.0].
 [#344]: https://github.com/ergebnis/front-matter/pull/344
 [#346]: https://github.com/ergebnis/front-matter/pull/346
 [#393]: https://github.com/ergebnis/front-matter/pull/393
+[#397]: https://github.com/ergebnis/front-matter/pull/397
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Parsed.php
+++ b/src/Parsed.php
@@ -24,7 +24,7 @@ final class Parsed
     ) {
     }
 
-    public static function fromFrontMatterAndContent(
+    public static function create(
         FrontMatter $frontMatter,
         Content $content,
     ): self {

--- a/src/YamlParser.php
+++ b/src/YamlParser.php
@@ -28,7 +28,7 @@ final class YamlParser implements Parser
     public function parse(string $value): Parsed
     {
         if (\preg_match(self::PATTERN, $value, $matches) !== 1) {
-            return Parsed::fromFrontMatterAndContent(
+            return Parsed::create(
                 FrontMatter::fromArray([]),
                 Content::fromString($value),
             );
@@ -39,7 +39,7 @@ final class YamlParser implements Parser
         $rawFrontMatter = $matches['frontMatter'];
 
         if ('' === $rawFrontMatter) {
-            return Parsed::fromFrontMatterAndContent(
+            return Parsed::create(
                 FrontMatter::fromArray([]),
                 $content,
             );
@@ -61,7 +61,7 @@ final class YamlParser implements Parser
             throw Exception\FrontMatterIsNotAnObject::create();
         }
 
-        return Parsed::fromFrontMatterAndContent(
+        return Parsed::create(
             $frontMatter,
             $content,
         );

--- a/test/Unit/ParsedTest.php
+++ b/test/Unit/ParsedTest.php
@@ -26,7 +26,7 @@ final class ParsedTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testFromFrontMatterAndContentReturnsParsed(): void
+    public function testCreateReturnsParsed(): void
     {
         $faker = self::faker();
 
@@ -38,7 +38,7 @@ final class ParsedTest extends Framework\TestCase
 
         $content = Content::fromString($faker->realText());
 
-        $parsed = Parsed::fromFrontMatterAndContent(
+        $parsed = Parsed::create(
             $frontMatter,
             $content,
         );


### PR DESCRIPTION
This pull request

- [x] renames `Parsed::fromFrontMatterAndContent()` to `Parsed::create()`
