### PR TITLE
Fix: Rename `Content` to `BodyMatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.1.0...main`][2.1.0...main].
 
 - Dropped support for PHP 8.0 ([#393]), by [@localheinz]
 - Renamed `Parsed::fromFrontMatterAndContent()` to `Parsed::create()` ([#397]), by [@localheinz]
+- Renamed `Content` to `BodyMatter` and `Parsed::content()` to `Parsed::bodyMatter()` ([#398]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 

--- a/src/BodyMatter.php
+++ b/src/BodyMatter.php
@@ -16,7 +16,7 @@ namespace Ergebnis\FrontMatter;
 /**
  * @psalm-immutable
  */
-final class Content
+final class BodyMatter
 {
     private function __construct(private readonly string $value)
     {

--- a/src/Parsed.php
+++ b/src/Parsed.php
@@ -20,17 +20,17 @@ final class Parsed
 {
     private function __construct(
         private readonly FrontMatter $frontMatter,
-        private readonly Content $content,
+        private readonly BodyMatter $bodyMatter,
     ) {
     }
 
     public static function create(
         FrontMatter $frontMatter,
-        Content $content,
+        BodyMatter $bodyMatter,
     ): self {
         return new self(
             $frontMatter,
-            $content,
+            $bodyMatter,
         );
     }
 
@@ -39,8 +39,8 @@ final class Parsed
         return $this->frontMatter;
     }
 
-    public function content(): Content
+    public function bodyMatter(): BodyMatter
     {
-        return $this->content;
+        return $this->bodyMatter;
     }
 }

--- a/src/YamlParser.php
+++ b/src/YamlParser.php
@@ -18,7 +18,7 @@ use Symfony\Component\Yaml;
 
 final class YamlParser implements Parser
 {
-    private const PATTERN = "{^(?:---)[\r\n|\n]*(?P<frontMatter>.*?)[\r\n|\n]+(?:---)[\r\n|\n]{0,1}(?P<content>.*)$}s";
+    private const PATTERN = "{^(?:---)[\r\n|\n]*(?P<frontMatter>.*?)[\r\n|\n]+(?:---)[\r\n|\n]{0,1}(?P<bodyMatter>.*)$}s";
 
     public function hasFrontMatter(string $value): bool
     {
@@ -30,18 +30,18 @@ final class YamlParser implements Parser
         if (\preg_match(self::PATTERN, $value, $matches) !== 1) {
             return Parsed::create(
                 FrontMatter::fromArray([]),
-                Content::fromString($value),
+                BodyMatter::fromString($value),
             );
         }
 
-        $content = Content::fromString($matches['content']);
+        $bodyMatter = BodyMatter::fromString($matches['bodyMatter']);
 
         $rawFrontMatter = $matches['frontMatter'];
 
         if ('' === $rawFrontMatter) {
             return Parsed::create(
                 FrontMatter::fromArray([]),
-                $content,
+                $bodyMatter,
             );
         }
 
@@ -63,7 +63,7 @@ final class YamlParser implements Parser
 
         return Parsed::create(
             $frontMatter,
-            $content,
+            $bodyMatter,
         );
     }
 }

--- a/test/Unit/BodyMatterTest.php
+++ b/test/Unit/BodyMatterTest.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
 namespace Ergebnis\FrontMatter\Test\Unit;
 
 use Ergebnis\DataProvider;
-use Ergebnis\FrontMatter\Content;
+use Ergebnis\FrontMatter\BodyMatter;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Content::class)]
-final class ContentTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(BodyMatter::class)]
+final class BodyMatterTest extends Framework\TestCase
 {
     #[Framework\Attributes\DataProviderExternal(DataProvider\StringProvider::class, 'arbitrary')]
-    public function testFromStringReturnsContent(string $value): void
+    public function testFromStringReturnsBodyMatter(string $value): void
     {
-        $content = Content::fromString($value);
+        $bodyMatter = BodyMatter::fromString($value);
 
-        self::assertSame($value, $content->toString());
+        self::assertSame($value, $bodyMatter->toString());
     }
 }

--- a/test/Unit/ParsedTest.php
+++ b/test/Unit/ParsedTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\FrontMatter\Test\Unit;
 
-use Ergebnis\FrontMatter\Content;
+use Ergebnis\FrontMatter\BodyMatter;
 use Ergebnis\FrontMatter\FrontMatter;
 use Ergebnis\FrontMatter\Parsed;
 use Ergebnis\FrontMatter\Test;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(Parsed::class)]
-#[Framework\Attributes\UsesClass(Content::class)]
+#[Framework\Attributes\UsesClass(BodyMatter::class)]
 #[Framework\Attributes\UsesClass(FrontMatter::class)]
 final class ParsedTest extends Framework\TestCase
 {
@@ -36,14 +36,14 @@ final class ParsedTest extends Framework\TestCase
             'baz' => $faker->randomNumber(),
         ]);
 
-        $content = Content::fromString($faker->realText());
+        $bodyMatter = BodyMatter::fromString($faker->realText());
 
         $parsed = Parsed::create(
             $frontMatter,
-            $content,
+            $bodyMatter,
         );
 
         self::assertSame($frontMatter, $parsed->frontMatter());
-        self::assertSame($content, $parsed->content());
+        self::assertSame($bodyMatter, $parsed->bodyMatter());
     }
 }

--- a/test/Unit/YamlParserTest.php
+++ b/test/Unit/YamlParserTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\FrontMatter\Test\Unit;
 
 use Ergebnis\DataProvider;
-use Ergebnis\FrontMatter\Content;
+use Ergebnis\FrontMatter\BodyMatter;
 use Ergebnis\FrontMatter\Exception;
 use Ergebnis\FrontMatter\FrontMatter;
 use Ergebnis\FrontMatter\Parsed;
@@ -23,7 +23,7 @@ use Ergebnis\FrontMatter\YamlParser;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(YamlParser::class)]
-#[Framework\Attributes\UsesClass(Content::class)]
+#[Framework\Attributes\UsesClass(BodyMatter::class)]
 #[Framework\Attributes\UsesClass(Exception\FrontMatterCanNotBeParsed::class)]
 #[Framework\Attributes\UsesClass(Exception\FrontMatterHasInvalidKeys::class)]
 #[Framework\Attributes\UsesClass(Exception\FrontMatterIsNotAnObject::class)]
@@ -64,7 +64,7 @@ TXT;
         self::assertFalse($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsFalseWhenValueIsFrontMatterDelimiterWithContent(): void
+    public function testHasFrontMatterReturnsFalseWhenValueIsFrontMatterDelimiterWithBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -78,7 +78,7 @@ TXT;
         self::assertFalse($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsFalseWhenValueIsFrontMatterDelimiterWithTrailingWhitespaceAndContent(): void
+    public function testHasFrontMatterReturnsFalseWhenValueIsFrontMatterDelimiterWithTrailingWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -117,7 +117,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterAndBlankContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -130,7 +130,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterAndContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -161,7 +161,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterWithWhitespaceAndBlankContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -176,7 +176,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterWithWhitespaceAndContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -211,7 +211,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterAndBlankContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -229,7 +229,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterAndContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -268,7 +268,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBlankContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -288,7 +288,7 @@ TXT;
         self::assertTrue($parser->hasFrontMatter($value));
     }
 
-    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterWithWhitespaceAndContent(): void
+    public function testHasFrontMatterReturnsTrueWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -322,7 +322,7 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString($value), $parsed->content());
+        self::assertEquals(BodyMatter::fromString($value), $parsed->bodyMatter());
     }
 
     public function testParseReturnsParsedWhenValueIsFrontMatterDelimiterWithTrailingWhitespace(): void
@@ -337,10 +337,10 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString($value), $parsed->content());
+        self::assertEquals(BodyMatter::fromString($value), $parsed->bodyMatter());
     }
 
-    public function testParseReturnsParsedWhenValueIsFrontMatterDelimiterWithContent(): void
+    public function testParseReturnsParsedWhenValueIsFrontMatterDelimiterWithBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -354,10 +354,10 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString($value), $parsed->content());
+        self::assertEquals(BodyMatter::fromString($value), $parsed->bodyMatter());
     }
 
-    public function testParseReturnsParsedWhenValueIsFrontMatterDelimiterWithTrailingWhitespaceAndContent(): void
+    public function testParseReturnsParsedWhenValueIsFrontMatterDelimiterWithTrailingWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -372,7 +372,7 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString($value), $parsed->content());
+        self::assertEquals(BodyMatter::fromString($value), $parsed->bodyMatter());
     }
 
     public function testParseReturnsParsedWhenValueIsAlmostEmptyFrontMatter(): void
@@ -387,7 +387,7 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString($value), $parsed->content());
+        self::assertEquals(BodyMatter::fromString($value), $parsed->bodyMatter());
     }
 
     public function testParseReturnsParsedWhenValueIsEmptyFrontMatter(): void
@@ -402,10 +402,10 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals(FrontMatter::fromArray([]), $parsed->frontMatter());
-        self::assertEquals(Content::fromString(''), $parsed->content());
+        self::assertEquals(BodyMatter::fromString(''), $parsed->bodyMatter());
     }
 
-    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterAndBlankContent(): void
+    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -419,13 +419,13 @@ TXT;
 
         $expected = Parsed::create(
             FrontMatter::fromArray([]),
-            Content::fromString(''),
+            BodyMatter::fromString(''),
         );
 
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterAndContent(): void
+    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -443,7 +443,7 @@ TXT;
 
         $expected = Parsed::create(
             FrontMatter::fromArray([]),
-            Content::fromString(
+            BodyMatter::fromString(
                 <<<'TXT'
 
 <h1>
@@ -472,13 +472,13 @@ TXT;
 
         $expected = Parsed::create(
             FrontMatter::fromArray([]),
-            Content::fromString(''),
+            BodyMatter::fromString(''),
         );
 
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterWithWhitespaceAndBlankContent(): void
+    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -494,13 +494,13 @@ TXT;
 
         $expected = Parsed::create(
             FrontMatter::fromArray([]),
-            Content::fromString(''),
+            BodyMatter::fromString(''),
         );
 
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterWithWhitespaceAndContent(): void
+    public function testParseReturnsParsedWhenValueHasEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -520,7 +520,7 @@ TXT;
 
         $expected = Parsed::create(
             FrontMatter::fromArray([]),
-            Content::fromString(<<<'TXT'
+            BodyMatter::fromString(<<<'TXT'
 
 <h1>
     Hello
@@ -663,10 +663,10 @@ TXT;
         $parsed = $parser->parse($value);
 
         self::assertEquals($frontMatter, $parsed->frontMatter());
-        self::assertEquals(Content::fromString(''), $parsed->content());
+        self::assertEquals(BodyMatter::fromString(''), $parsed->bodyMatter());
     }
 
-    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterAndBlankContent(): void
+    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -691,7 +691,7 @@ TXT;
                     'quz',
                 ],
             ]),
-            Content::fromString(<<<'TXT'
+            BodyMatter::fromString(<<<'TXT'
 
 
 TXT),
@@ -700,7 +700,7 @@ TXT),
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterAndContent(): void
+    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -728,7 +728,7 @@ TXT;
                     'quz',
                 ],
             ]),
-            Content::fromString(<<<'TXT'
+            BodyMatter::fromString(<<<'TXT'
 
 <h1>
     Hello
@@ -765,13 +765,13 @@ TXT;
                     'quz',
                 ],
             ]),
-            Content::fromString(''),
+            BodyMatter::fromString(''),
         );
 
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBlankContent(): void
+    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -798,7 +798,7 @@ TXT;
                     'quz',
                 ],
             ]),
-            Content::fromString(<<<'TXT'
+            BodyMatter::fromString(<<<'TXT'
 
 
 TXT),
@@ -807,7 +807,7 @@ TXT),
         self::assertEquals($expected, $parsed);
     }
 
-    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterWithWhitespaceAndContent(): void
+    public function testParseReturnsParsedWhenValueHasNonEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $value = <<<'TXT'
 ---
@@ -837,7 +837,7 @@ TXT;
                     'quz',
                 ],
             ]),
-            Content::fromString(<<<'TXT'
+            BodyMatter::fromString(<<<'TXT'
 
 <h1>
     Hello


### PR DESCRIPTION
This pull request

- [x] renames `Content` to `BodyMatter`