### PR TITLE
Fix: Rename `Parsed` to `ParsedContent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`2.1.0...main`][2.1.0...main].
 - Renamed `Parsed::fromFrontMatterAndContent()` to `Parsed::create()` ([#397]), by [@localheinz]
 - Renamed `Content` to `BodyMatter` and `Parsed::content()` to `Parsed::bodyMatter()` ([#398]), by [@localheinz]
 - Extracted `Content` as a value object ([#399]), by [@localheinz]
+- Renamed `Parsed` to `ParsedContent` ([#400]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -106,5 +107,6 @@ For a full diff see [`4e97e14...0.1.0`][4e97e14...0.1.0].
 [#397]: https://github.com/ergebnis/front-matter/pull/397
 [#398]: https://github.com/ergebnis/front-matter/pull/398
 [#399]: https://github.com/ergebnis/front-matter/pull/399
+[#400]: https://github.com/ergebnis/front-matter/pull/400
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ $parser = new FrontMatter\YamlParser();
 
 $contentWithoutFrontMatter = FrontMatter\Content::fromString('Hello, how are you today?');
 
-/** @var FrontMatter\Parsed $parsed */
-$parsed = $parser->parse($contentWithoutFrontMatter);
+/** @var FrontMatter\ParsedContent $parsedContent */
+$parsedContent = $parser->parse($contentWithoutFrontMatter);
 
 $contentWithFrontMatter = FrontMatter\Content::fromString(
     <<<TXT
@@ -84,13 +84,13 @@ page:
 TXT
 );
 
-/** @var FrontMatter\Parsed $parsed */
-$parsed = $parser->parse($contentWithoutFrontMatter);
+/** @var FrontMatter\ParsedContent $parsedContent */
+$parsedContent = $parser->parse($contentWithoutFrontMatter);
 ```
 
 :exclamation: The `YamlParser` will throw an [`Ergebnis\FrontMatter\Exception\FrontMatterCanNotBeParsed`](src/Exception/FrontMatterCanNotBeParsed.php) exception when the front matter is invalid YAML and an [`Ergebnis\FrontMatter\Exception\FrontMatterIsNotAnObject`](src/Exception/FrontMatterIsNotAnObject.php) exception when the front matter does not describe an object.
 
-:bulb: The `YamlParser` returns an [`Ergebnis\FrontMatter\Parsed`](src/Parsed.php) value object on success, regardless of whether the value has front matter or not.
+:bulb: The `YamlParser` returns an [`Ergebnis\FrontMatter\Parsed`](src/ParsedContent.php) value object on success, regardless of whether the value has front matter or not.
 
 ## Changelog
 

--- a/src/ParsedContent.php
+++ b/src/ParsedContent.php
@@ -16,7 +16,7 @@ namespace Ergebnis\FrontMatter;
 /**
  * @psalm-immutable
  */
-final class Parsed
+final class ParsedContent
 {
     private function __construct(
         private readonly FrontMatter $frontMatter,

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -21,5 +21,5 @@ interface Parser
      * @throws Exception\FrontMatterIsNotAnObject
      * @throws Exception\FrontMatterCanNotBeParsed
      */
-    public function parse(Content $content): Parsed;
+    public function parse(Content $content): ParsedContent;
 }

--- a/src/YamlParser.php
+++ b/src/YamlParser.php
@@ -25,10 +25,10 @@ final class YamlParser implements Parser
         return \preg_match(self::PATTERN, $content->toString()) === 1;
     }
 
-    public function parse(Content $content): Parsed
+    public function parse(Content $content): ParsedContent
     {
         if (\preg_match(self::PATTERN, $content->toString(), $matches) !== 1) {
-            return Parsed::create(
+            return ParsedContent::create(
                 FrontMatter::fromArray([]),
                 BodyMatter::fromString($content->toString()),
             );
@@ -39,7 +39,7 @@ final class YamlParser implements Parser
         $rawFrontMatter = $matches['frontMatter'];
 
         if ('' === $rawFrontMatter) {
-            return Parsed::create(
+            return ParsedContent::create(
                 FrontMatter::fromArray([]),
                 $bodyMatter,
             );
@@ -61,7 +61,7 @@ final class YamlParser implements Parser
             throw Exception\FrontMatterIsNotAnObject::create();
         }
 
-        return Parsed::create(
+        return ParsedContent::create(
             $frontMatter,
             $bodyMatter,
         );

--- a/test/Unit/ParsedContentTest.php
+++ b/test/Unit/ParsedContentTest.php
@@ -15,18 +15,18 @@ namespace Ergebnis\FrontMatter\Test\Unit;
 
 use Ergebnis\FrontMatter\BodyMatter;
 use Ergebnis\FrontMatter\FrontMatter;
-use Ergebnis\FrontMatter\Parsed;
+use Ergebnis\FrontMatter\ParsedContent;
 use Ergebnis\FrontMatter\Test;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Parsed::class)]
+#[Framework\Attributes\CoversClass(ParsedContent::class)]
 #[Framework\Attributes\UsesClass(BodyMatter::class)]
 #[Framework\Attributes\UsesClass(FrontMatter::class)]
-final class ParsedTest extends Framework\TestCase
+final class ParsedContentTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testCreateReturnsParsed(): void
+    public function testCreateReturnsParsedContent(): void
     {
         $faker = self::faker();
 
@@ -38,12 +38,12 @@ final class ParsedTest extends Framework\TestCase
 
         $bodyMatter = BodyMatter::fromString($faker->realText());
 
-        $parsed = Parsed::create(
+        $parsedContent = ParsedContent::create(
             $frontMatter,
             $bodyMatter,
         );
 
-        self::assertSame($frontMatter, $parsed->frontMatter());
-        self::assertSame($bodyMatter, $parsed->bodyMatter());
+        self::assertSame($frontMatter, $parsedContent->frontMatter());
+        self::assertSame($bodyMatter, $parsedContent->bodyMatter());
     }
 }

--- a/test/Unit/YamlParserTest.php
+++ b/test/Unit/YamlParserTest.php
@@ -18,7 +18,7 @@ use Ergebnis\FrontMatter\BodyMatter;
 use Ergebnis\FrontMatter\Content;
 use Ergebnis\FrontMatter\Exception;
 use Ergebnis\FrontMatter\FrontMatter;
-use Ergebnis\FrontMatter\Parsed;
+use Ergebnis\FrontMatter\ParsedContent;
 use Ergebnis\FrontMatter\Test;
 use Ergebnis\FrontMatter\YamlParser;
 use PHPUnit\Framework;
@@ -30,7 +30,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Exception\FrontMatterHasInvalidKeys::class)]
 #[Framework\Attributes\UsesClass(Exception\FrontMatterIsNotAnObject::class)]
 #[Framework\Attributes\UsesClass(FrontMatter::class)]
-#[Framework\Attributes\UsesClass(Parsed::class)]
+#[Framework\Attributes\UsesClass(ParsedContent::class)]
 final class YamlParserTest extends Framework\TestCase
 {
     use Test\Util\Helper;
@@ -341,7 +341,7 @@ TXT
         self::assertTrue($parser->hasFrontMatter($content));
     }
 
-    public function testParseReturnsParsedWhenContentIsFrontMatterDelimiter(): void
+    public function testParseReturnsParsedContentWhenContentIsFrontMatterDelimiter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -351,17 +351,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString($content->toString()),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsFrontMatterDelimiterWithTrailingWhitespace(): void
+    public function testParseReturnsParsedContentWhenContentIsFrontMatterDelimiterWithTrailingWhitespace(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -372,17 +372,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString($content->toString()),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsFrontMatterDelimiterWithBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentIsFrontMatterDelimiterWithBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -396,17 +396,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString($content->toString()),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsFrontMatterDelimiterWithTrailingWhitespaceAndBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentIsFrontMatterDelimiterWithTrailingWhitespaceAndBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -420,17 +420,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString($content->toString()),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsAlmostEmptyFrontMatter(): void
+    public function testParseReturnsParsedContentWhenContentIsAlmostEmptyFrontMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -441,17 +441,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString($content->toString()),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsEmptyFrontMatter(): void
+    public function testParseReturnsParsedContentWhenContentIsEmptyFrontMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -462,17 +462,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(''),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasEmptyFrontMatterAndBlankBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -484,17 +484,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(''),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasEmptyFrontMatterAndBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasEmptyFrontMatterAndBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -510,9 +510,9 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(
                 <<<'TXT'
@@ -525,10 +525,10 @@ TXT
             ),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsEmptyFrontMatterWithWhitespace(): void
+    public function testParseReturnsParsedContentWhenContentIsEmptyFrontMatterWithWhitespace(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -541,17 +541,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(''),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -565,17 +565,17 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(''),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -593,9 +593,9 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([]),
             BodyMatter::fromString(<<<'TXT'
 
@@ -606,7 +606,7 @@ TXT
 TXT),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
     public function testParseThrowsFrontMatterCanNotBeParsedWhenFrontMatterCanNotBeParsed(): void
@@ -728,7 +728,7 @@ TXT
         $parser->parse($content);
     }
 
-    public function testParseReturnsParsedWhenContentIsNonEmptyFrontMatter(): void
+    public function testParseReturnsParsedContentWhenContentIsNonEmptyFrontMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -751,13 +751,13 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        self::assertEquals($frontMatter, $parsed->frontMatter());
-        self::assertEquals(BodyMatter::fromString(''), $parsed->bodyMatter());
+        self::assertEquals($frontMatter, $parsedContent->frontMatter());
+        self::assertEquals(BodyMatter::fromString(''), $parsedContent->bodyMatter());
     }
 
-    public function testParseReturnsParsedWhenContentHasNonEmptyFrontMatterAndBlankBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasNonEmptyFrontMatterAndBlankBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -774,9 +774,9 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([
                 'foo' => 'bar',
                 'baz' => [
@@ -790,10 +790,10 @@ TXT
 TXT),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasNonEmptyFrontMatterAndBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasNonEmptyFrontMatterAndBodyMatter(): void
     {
         $content = Content::fromString(<<<'TXT'
 ---
@@ -811,9 +811,9 @@ TXT);
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([
                 'foo' => 'bar',
                 'baz' => [
@@ -830,10 +830,10 @@ TXT);
 TXT),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentIsNonEmptyFrontMatterWithWhitespace(): void
+    public function testParseReturnsParsedContentWhenContentIsNonEmptyFrontMatterWithWhitespace(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -850,9 +850,9 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([
                 'foo' => 'bar',
                 'baz' => [
@@ -863,10 +863,10 @@ TXT
             BodyMatter::fromString(''),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasNonEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasNonEmptyFrontMatterWithWhitespaceAndBlankBodyMatter(): void
     {
         $content = Content::fromString(<<<'TXT'
 ---
@@ -883,9 +883,9 @@ TXT);
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([
                 'foo' => 'bar',
                 'baz' => [
@@ -899,10 +899,10 @@ TXT);
 TXT),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 
-    public function testParseReturnsParsedWhenContentHasNonEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
+    public function testParseReturnsParsedContentWhenContentHasNonEmptyFrontMatterWithWhitespaceAndBodyMatter(): void
     {
         $content = Content::fromString(
             <<<'TXT'
@@ -924,9 +924,9 @@ TXT
 
         $parser = new YamlParser();
 
-        $parsed = $parser->parse($content);
+        $parsedContent = $parser->parse($content);
 
-        $expected = Parsed::create(
+        $expected = ParsedContent::create(
             FrontMatter::fromArray([
                 'foo' => 'bar',
                 'baz' => [
@@ -943,6 +943,6 @@ TXT
 TXT),
         );
 
-        self::assertEquals($expected, $parsed);
+        self::assertEquals($expected, $parsedContent);
     }
 }


### PR DESCRIPTION
This pull request

- [x] renames `Parsed` to `ParsedContent`