### PR TITLE
Fix: Rename `Exception\FrontMatterDoesNotHaveKey` to `Exception\DataDoesNotHaveKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`2.1.0...main`][2.1.0...main].
 - Renamed `Parsed::fromFrontMatterAndContent()` to `Parsed::create()` ([#397]), by [@localheinz]
 - Extracted `BodyMatter` as a value object ([#398]), by [@localheinz]
 - Started composing `Content` and `Data` into `FrontMatter` ([#409]), by [@localheinz]
+- Renamed `Exception\FrontMatterDoesNotHaveKey` to `Exception\DataDoesNotHaveKey` ([#410]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -109,5 +110,6 @@ For a full diff see [`4e97e14...0.1.0`][4e97e14...0.1.0].
 [#400]: https://github.com/ergebnis/front-matter/pull/400
 [#407]: https://github.com/ergebnis/front-matter/pull/407
 [#409]: https://github.com/ergebnis/front-matter/pull/409
+[#410]: https://github.com/ergebnis/front-matter/pull/410
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Data.php
+++ b/src/Data.php
@@ -87,13 +87,13 @@ final class Data
     }
 
     /**
-     * @throws Exception\FrontMatterDoesNotHaveKey
+     * @throws Exception\DataDoesNotHaveKey
      */
     public function get(string $key): mixed
     {
         if (!\str_contains($key, '.')) {
             if (!\array_key_exists($key, $this->value)) {
-                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+                throw Exception\DataDoesNotHaveKey::named($key);
             }
 
             return $this->value[$key];
@@ -112,7 +112,7 @@ final class Data
             $part = $parts[$i];
 
             if (!\array_key_exists($part, $value)) {
-                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+                throw Exception\DataDoesNotHaveKey::named($key);
             }
 
             $value = $value[$part];
@@ -121,7 +121,7 @@ final class Data
                 $count - 1 > $i
                 && !\is_array($value)
             ) {
-                throw Exception\FrontMatterDoesNotHaveKey::named($key);
+                throw Exception\DataDoesNotHaveKey::named($key);
             }
         }
 

--- a/src/Exception/DataDoesNotHaveKey.php
+++ b/src/Exception/DataDoesNotHaveKey.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Ergebnis\FrontMatter\Exception;
 
-final class FrontMatterDoesNotHaveKey extends \InvalidArgumentException
+final class DataDoesNotHaveKey extends \InvalidArgumentException
 {
     public static function named(string $key): self
     {
         return new self(\sprintf(
-            'Front matter does not have a key named "%s".',
+            'Data does not have a key named "%s".',
             $key,
         ));
     }

--- a/test/Unit/DataTest.php
+++ b/test/Unit/DataTest.php
@@ -17,7 +17,7 @@ use Ergebnis\FrontMatter\Test;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(Data::class)]
-#[Framework\Attributes\UsesClass(Exception\FrontMatterDoesNotHaveKey::class)]
+#[Framework\Attributes\UsesClass(Exception\DataDoesNotHaveKey::class)]
 #[Framework\Attributes\UsesClass(Exception\FrontMatterHasInvalidKeys::class)]
 final class DataTest extends Framework\TestCase
 {
@@ -163,13 +163,13 @@ final class DataTest extends Framework\TestCase
         self::assertTrue($data->has('head.meta.author'));
     }
 
-    public function testGetThrowsFrontMatterDoesNotHaveKeyExceptionWhenDataIsEmpty(): void
+    public function testGetThrowsDataDoesNotHaveKeyExceptionWhenDataIsEmpty(): void
     {
         $key = self::faker()->word();
 
         $data = Data::fromArray([]);
 
-        $this->expectException(Exception\FrontMatterDoesNotHaveKey::class);
+        $this->expectException(Exception\DataDoesNotHaveKey::class);
 
         $data->get($key);
     }
@@ -187,7 +187,7 @@ final class DataTest extends Framework\TestCase
 
         $data = Data::fromArray($value);
 
-        $this->expectException(Exception\FrontMatterDoesNotHaveKey::class);
+        $this->expectException(Exception\DataDoesNotHaveKey::class);
 
         $data->get($key);
     }
@@ -213,7 +213,7 @@ final class DataTest extends Framework\TestCase
     {
         $data = Data::fromArray($value);
 
-        $this->expectException(Exception\FrontMatterDoesNotHaveKey::class);
+        $this->expectException(Exception\DataDoesNotHaveKey::class);
 
         $data->get('head.meta.author');
     }

--- a/test/Unit/Exception/DataDoesNotHaveKeyTest.php
+++ b/test/Unit/Exception/DataDoesNotHaveKeyTest.php
@@ -17,8 +17,8 @@ use Ergebnis\FrontMatter\Exception;
 use Ergebnis\FrontMatter\Test;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Exception\FrontMatterDoesNotHaveKey::class)]
-final class FrontMatterDoesNotHaveKeyTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Exception\DataDoesNotHaveKey::class)]
+final class DataDoesNotHaveKeyTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
@@ -26,10 +26,10 @@ final class FrontMatterDoesNotHaveKeyTest extends Framework\TestCase
     {
         $key = self::faker()->word();
 
-        $exception = Exception\FrontMatterDoesNotHaveKey::named($key);
+        $exception = Exception\DataDoesNotHaveKey::named($key);
 
         $message = \sprintf(
-            'Front matter does not have a key named "%s".',
+            'Data does not have a key named "%s".',
             $key,
         );
 


### PR DESCRIPTION
This pull request

- [x] renames `Exception\FrontMatterDoesNotHaveKey` to `Exception\DataDoesNotHaveKey`
