### PR TITLE
Fix: Do not configure `platform`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,6 @@
     "audit": {
       "abandoned": "report"
     },
-    "platform": {
-      "php": "8.1.20"
-    },
     "preferred-install": "dist",
     "sort-packages": true
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdf89618c4ef6b0199e8d2df78edf1b0",
+    "content-hash": "f60471fa0f2b4670cf021409f39f6898",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",
@@ -6344,8 +6344,5 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "8.1.20"
-    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request

- [x] stops configuring the [`platform`](https://getcomposer.org/doc/06-config.md#platform) in `composer.json`

Follows https://github.com/ergebnis/php-package-template/pull/1376.